### PR TITLE
#31 - Replace `data` property  method overrides with `to_representation`

### DIFF
--- a/deadline_/accounts/serializers.py
+++ b/deadline_/accounts/serializers.py
@@ -1,5 +1,8 @@
+from collections import OrderedDict
+
 from rest_framework import serializers
-from accounts.models import User, Role
+
+from accounts.models import User
 
 
 class UserSerializer(serializers.ModelSerializer):
@@ -7,11 +10,10 @@ class UserSerializer(serializers.ModelSerializer):
         model = User
         fields = ('id', 'username', 'email', 'password', 'score', 'role')
 
-    @property
-    def data(self):
-        """
-        Attach the Role's name
-        """
-        loaded_data = super().data
-        loaded_data['role'] = Role.objects.get(id=loaded_data['role']).name
-        return loaded_data
+    def to_representation(self, instance):
+        repr = dict(super().to_representation(instance))
+
+        del repr['password']
+        repr['role'] = {'id': self.instance.role.id, 'name': self.instance.role.name}
+
+        return OrderedDict(repr)

--- a/deadline_/education/serializers.py
+++ b/deadline_/education/serializers.py
@@ -19,19 +19,13 @@ class CourseSerializer(serializers.ModelSerializer):
     def get_lessons(self, obj):
         return [{'consecutive_number': lesson.lesson_number, 'short_description': lesson.intro} for lesson in obj.lessons.all()]
 
-    @property
-    def data(self):
-        """
-            Attach the Language's name in the deserialization
-             This is SQL-expensive and I will probably curse myself later on for adding this.
-             You can always speed it up by builsupported_ding the language IDs and doing one SQL query
-        """
-        loaded_data = super().data
+    def to_representation(self, instance):
+        repr = super().to_representation(instance)
 
-        loaded_data['languages'] = [Language.objects.get(id=lang_id).name for lang_id in loaded_data['languages']]
-        loaded_data['main_teacher'] = {'name': self.instance.main_teacher.username, 'id': self.instance.main_teacher.id}
+        repr['main_teacher'] = {'name': self.instance.main_teacher.username, 'id': self.instance.main_teacher.id}
+        repr['languages'] = [lang.name for lang in self.instance.languages.all()]
 
-        return loaded_data
+        return repr
 
 
 class HomeworkTaskDescriptionSerializer(serializers.ModelSerializer):

--- a/deadline_/education/serializers.py
+++ b/deadline_/education/serializers.py
@@ -93,34 +93,21 @@ class HomeworkTaskSerializer(serializers.ModelSerializer):
     def get_test_case_count(self, obj):
         return obj.test_case_count
 
-    @property
-    def data(self):
-        """
-            Attach the Language's name in the deserialization
-             This is SQL-expensive and I will probably curse myself later on for adding this.
-             You can always speed it up by building the language IDs and doing one SQL query
-            Also attach the test_case_count
-        """
-        loaded_data = super().data
-        loaded_data['supported_languages'] = [Language.objects.get(id=lang_id).name for lang_id in loaded_data['supported_languages']]
-
-        return loaded_data
+    def to_representation(self, instance):
+        repr = super().to_representation(instance)
+        repr['supported_languages'] = [lang.name for lang in instance.supported_languages.all()]
+        return repr
 
 
 class HomeworkSerializer(serializers.ModelSerializer):
+    tasks = serializers.SerializerMethodField()
+
     class Meta:
         model = Homework
-        fields = ('is_mandatory',)
+        fields = ('is_mandatory', 'tasks')
 
-    @property
-    def data(self):
-        """
-            Attach the HomeworkTasks
-        """
-        loaded_data = super().data
-        loaded_data['tasks'] = [HomeworkTaskSerializer(hw).data for hw in self.instance.homeworktask_set.all()]
-
-        return loaded_data
+    def get_tasks(self, obj):
+        return [HomeworkTaskSerializer(hw).data for hw in self.instance.homeworktask_set.all()]
 
 
 class TaskSubmissionSerializer(serializers.ModelSerializer):

--- a/deadline_/education/tests/views/test_course.py
+++ b/deadline_/education/tests/views/test_course.py
@@ -8,6 +8,7 @@ from challenges.tests.base import TestHelperMixin
 from education.models import Course, Lesson
 from challenges.models import Language
 from accounts.models import User, Role
+from education.serializers import CourseSerializer
 from education.views.course_views import CourseManageView, CourseEditView, CourseDetailsView
 
 
@@ -83,7 +84,7 @@ class CourseDetailsViewTests(TestCase, TestHelperMixin):
     def test_teacher_can_view(self):
         resp = self.client.get(f'/education/course/{self.course.id}', HTTP_AUTHORIZATION=self.teacher_auth_token)
         self.assertNotEqual(resp.status_code, 403)
-        self.assertEqual(resp.data['name'], 'Python Fundamentals')
+        self.assertEqual(resp.data, CourseSerializer(instance=self.course).data)
 
     def test_view_returns_data_as_expected(self):
         expected_data = {'name': 'Python Fundamentals', 'difficulty': 1.0, 'languages': ['Python'],


### PR DESCRIPTION
`to_representation` is the method to be overridden when you want to change the data that a `Serializer` returns. `data` is an internal method which gets called by `to_representation` and is not meant to be overridden.

This fixes places in the code where this was mistakenly done so.

Closes #31 